### PR TITLE
fix: escape HTML entities in markdown to prevent Vue parser errors

### DIFF
--- a/docs/builds/2026-02-05_14-58Z_1.110.0-insider_45934c7.md
+++ b/docs/builds/2026-02-05_14-58Z_1.110.0-insider_45934c7.md
@@ -57,7 +57,7 @@ Version: `1.110.0-insider` · Branch: `main` · Upstream: [microsoft/vscode](htt
   > Prevents agent status indicator background from changing when debugging, maintaining consistent UI coloring.
 - [#293053](https://github.com/microsoft/vscode/pull/293053) **BUILD: Revert "fix: associate extHost lifecycle to window"**
   > Reverts a prior change linking extension host lifecycle to windows, returning to immediate extension host termination on window close.
-- [#289457](https://github.com/microsoft/vscode/pull/289457) **vscode-dts: Add LineCommentConfig interface & update lineComment**
+- [#289457](https://github.com/microsoft/vscode/pull/289457) **vscode-dts: Add LineCommentConfig interface &amp; update lineComment**
   > Internal maintenance/refactoring; no user-visible change expected.
 - [#293043](https://github.com/microsoft/vscode/pull/293043) **Fix flaky tests by freezing time**
   > Fixes flaky update status bar tests by freezing time during test runs for consistent behavior.

--- a/docs/builds/2026-02-06_16-36Z_1.110.0-insider_c308cc9.md
+++ b/docs/builds/2026-02-06_16-36Z_1.110.0-insider_c308cc9.md
@@ -16,7 +16,7 @@ Version: `1.110.0-insider` · Branch: `main` · Upstream: [microsoft/vscode](htt
   > Adds an update action button to the Release Notes page, letting users conveniently download or apply updates directly from the release notes.
 - [#293371](https://github.com/microsoft/vscode/pull/293371) **Adds user interactive service to allow mocking focus/hover states (in inline completions).**
   > Introduces a user interaction service to track and mock focus, hover, and modifier keys, aiding testing especially for inline completions.
-- [#293355](https://github.com/microsoft/vscode/pull/293355) **Adds kusto exploration instructions & improves telemetry types**
+- [#293355](https://github.com/microsoft/vscode/pull/293355) **Adds kusto exploration instructions &amp; improves telemetry types**
   > Adds Kusto exploration instructions and tightens telemetry event types for improved tracking and analysis in edit telemetry.
 
 ## 🐛 FIXES

--- a/docs/builds/2026-02-09_08-27Z_1.110.0-insider_d565dc1.md
+++ b/docs/builds/2026-02-09_08-27Z_1.110.0-insider_d565dc1.md
@@ -83,7 +83,7 @@ Version: `1.110.0-insider` · Branch: `main` · Upstream: [microsoft/vscode](htt
   > Updates chat hook resolution to be OS-aware, enabling correct hook detection and behavior for remote environments like SSH or WSL.
 - [#293625](https://github.com/microsoft/vscode/pull/293625) **Update status bar entry bug fixes**
   > Fixes update status bar hover showing invalid release date and enhances version display with commit IDs, improving clarity on macOS update info.
-- [#293570](https://github.com/microsoft/vscode/pull/293570) **Limit the subagent model to a model with multiplier <= the main agent**
+- [#293570](https://github.com/microsoft/vscode/pull/293570) **Limit the subagent model to a model with multiplier &lt;= the main agent**
   > Enhances subagent model selection using a numerical multiplier to ensure subagents use models with equal or lesser cost than the main agent.
 - [#293523](https://github.com/microsoft/vscode/pull/293523) **Polish agent sessions list UI**
   > Polishes agent sessions list UI with better spacing, coloring, and focus outlines to improve visual clarity and interaction feedback.

--- a/docs/builds/2026-02-10_04-10Z_1.110.0-insider_417deb3.md
+++ b/docs/builds/2026-02-10_04-10Z_1.110.0-insider_417deb3.md
@@ -54,7 +54,7 @@ Version: `1.110.0-insider` · Branch: `main` · Upstream: [microsoft/vscode](htt
 
 ## 🔨 REFACTORS
 
-- [#294044](https://github.com/microsoft/vscode/pull/294044) **Use chat sessions controllers for extHost <-> mainThread**
+- [#294044](https://github.com/microsoft/vscode/pull/294044) **Use chat sessions controllers for extHost &lt;-&gt; mainThread**
   > Migrates the chat sessions model to use push-based controllers between extension host and main thread, improving session item updates for chat features.
 - [#294032](https://github.com/microsoft/vscode/pull/294032) **Extracts generateColorThemeCSS to enable reuse**
   > Extracts theme CSS generation into a reusable helper function enabling other theme-related code to generate consistent color theme styles.

--- a/docs/builds/2026-02-18_04-12Z_1.110.0-insider_e67a6f8.md
+++ b/docs/builds/2026-02-18_04-12Z_1.110.0-insider_e67a6f8.md
@@ -94,7 +94,7 @@ Version: `1.110.0-insider` · Branch: `main` · Upstream: [microsoft/vscode](htt
 - [#295815](https://github.com/microsoft/vscode/pull/295815) **fix sending new chat request in sessions window**
   > Fixed race conditions in the sessions window when sending new chat requests to ensure correct session loading and display.
 - [#295412](https://github.com/microsoft/vscode/pull/295412) **fix: add missing closing '>' in keybinding placeholder in accessible view navigation hint**
-  > Fixed missing closing '>' in accessible view navigation hint keybinding placeholder to show proper keybinding labels to screen readers.
+  > Fixed missing closing '&gt;' in accessible view navigation hint keybinding placeholder to show proper keybinding labels to screen readers.
 - [#294351](https://github.com/microsoft/vscode/pull/294351) **Chat input styling: border radius, icon colors, toolbar tweaks**
   > Improved chat input styling by updating border radius, icon colors, toolbar styles, and padding for a cleaner look.
 - [#295814](https://github.com/microsoft/vscode/pull/295814) **don't eval task output with llm unless the task lacks problem matchers**

--- a/docs/builds/2026-02-23_16-52Z_1.110.0-insider_6202855.md
+++ b/docs/builds/2026-02-23_16-52Z_1.110.0-insider_6202855.md
@@ -59,8 +59,8 @@ Version: `1.110.0-insider` · Branch: `main` · Upstream: [microsoft/vscode](htt
   > Improves security of trusted JSON schemas by restricting trusted domains, reducing exposure to potentially unsafe schema downloads.
 - [#296301](https://github.com/microsoft/vscode/pull/296301) **Remove Restore to Last Checkpoint from chat**
   > Removes the redundant "Restore to Last Checkpoint" chat action and its related tips, simplifying checkpoint restoration UI.
-- [#296300](https://github.com/microsoft/vscode/pull/296300) **Fix: Chat "Files & Folders" context picker returns no results when searching by file name**
-  > Fixes chat context picker to correctly find files by name when searching via "Files & Folders" by adjusting the search glob pattern.
+- [#296300](https://github.com/microsoft/vscode/pull/296300) **Fix: Chat "Files &amp; Folders" context picker returns no results when searching by file name**
+  > Fixes chat context picker to correctly find files by name when searching via "Files &amp; Folders" by adjusting the search glob pattern.
 - [#296922](https://github.com/microsoft/vscode/pull/296922) **fix duplicate models in sessions window**
   > Addresses duplicate model entries in Sessions window by filtering out background-targeted models from the model picker list.
 - [#296919](https://github.com/microsoft/vscode/pull/296919) **fix #296916**

--- a/docs/builds/2026-02-27_02-42Z_1.110.0-insider_37f3964.md
+++ b/docs/builds/2026-02-27_02-42Z_1.110.0-insider_37f3964.md
@@ -53,7 +53,7 @@ Version: `1.110.0-insider` · Branch: `main` · Upstream: [microsoft/vscode](htt
   > Improved debug panel UI by grouping files and fixing focus restoration, enhancing debugging flow for users.
 - [#297874](https://github.com/microsoft/vscode/pull/297874) **Fix Integrated Browser Localhost Opener triggering in too many cases**
   > Prevented integrated browser from opening localhost links when external openers are disabled, respecting user settings.
-- [#298070](https://github.com/microsoft/vscode/pull/298070) **Fixes vite warnings & improves pipeline**
+- [#298070](https://github.com/microsoft/vscode/pull/298070) **Fixes vite warnings &amp; improves pipeline**
   > Suppressed Vite dynamic import warnings and enhanced GitHub Actions pipeline UX for component screenshots.
 - [#298038](https://github.com/microsoft/vscode/pull/298038) **plugins: fix mcp server discovery in plugins**
   > Fixed MCP server discovery for agent plugins by correcting sort order, display label, and trust logic, improving plugin visibility.

--- a/docs/builds/2026-03-12_08-28Z_1.112.0-insider_03d87f6.md
+++ b/docs/builds/2026-03-12_08-28Z_1.112.0-insider_03d87f6.md
@@ -83,7 +83,7 @@ Version: `1.112.0-insider` · Branch: `main` · Upstream: [microsoft/vscode](htt
 - [#300860](https://github.com/microsoft/vscode/pull/300860) **Re-remove webpack (again again)**
   > Removes webpack from the root build pipeline, moving Monaco test bundling to local webpack dependencies for simplified setup.
 - [#300926](https://github.com/microsoft/vscode/pull/300926) **Simplify \`chat.autoReply\`: skip questions instead of LLM-answering them**
-  > Simplifies auto-reply by skipping questions with a fixed autopilot response instead of querying a separate model, reducing cost & complexity.
+  > Simplifies auto-reply by skipping questions with a fixed autopilot response instead of querying a separate model, reducing cost &amp; complexity.
 - [#300868](https://github.com/microsoft/vscode/pull/300868) **Using computed editor options instead of direct values**
   > Refactors editor line-break calculations to use computed editor options instead of passing many direct values, simplifying option handling.
 - [#300465](https://github.com/microsoft/vscode/pull/300465) **make integrated browser attach to chat feature kb accessible**

--- a/docs/builds/2026-03-16_04-25Z_1.112.0-insider_6da8508.md
+++ b/docs/builds/2026-03-16_04-25Z_1.112.0-insider_6da8508.md
@@ -11,7 +11,7 @@ Version: `1.112.0-insider` · Branch: `main` · Upstream: [microsoft/vscode](htt
 ## ✨ NEW
 
 - [#301640](https://github.com/microsoft/vscode/pull/301640) **Add "Workbench > Browser" settings category**
-  > Adds a new 'Workbench > Browser' settings category to help users find browser-related settings more easily in the VS Code settings UI.
+  > Adds a new 'Workbench &gt; Browser' settings category to help users find browser-related settings more easily in the VS Code settings UI.
 - [#301734](https://github.com/microsoft/vscode/pull/301734) **Expose chat.resizeImage command**
   > Adds an internal command to resize chat images, allowing other components and extensions to reuse the resizing logic via commands.
 - [#301657](https://github.com/microsoft/vscode/pull/301657) **Enhance image handling in chat attachments**

--- a/docs/builds/2026-03-27_03-48Z_1.114.0-insider_248457d.md
+++ b/docs/builds/2026-03-27_03-48Z_1.114.0-insider_248457d.md
@@ -81,7 +81,7 @@ Version: `1.114.0-insider` · Branch: `main` · Upstream: [microsoft/vscode](htt
   > Registered AI edits-related commands unconditionally to prevent "command not found" errors during git operations.
 - [#305247](https://github.com/microsoft/vscode/pull/305247) **Minor browser border style changes**
   > Refined browser border styles for a cleaner UI appearance with subtle visual improvements.
-- [#305244](https://github.com/microsoft/vscode/pull/305244) **Browser favicons: better error handling & data URL support**
+- [#305244](https://github.com/microsoft/vscode/pull/305244) **Browser favicons: better error handling &amp; data URL support**
   > Improved favicon handling in the browser by adding better error handling and support for data URLs.
 - [#305290](https://github.com/microsoft/vscode/pull/305290) **sessions - some fixes**
   > Various fixes and improvements in Sessions but details unspecified, likely bug fixes and polish.

--- a/docs/builds/2026-03-30_03-21Z_1.114.0-insider_ee6bfc5.md
+++ b/docs/builds/2026-03-30_03-21Z_1.114.0-insider_ee6bfc5.md
@@ -122,7 +122,7 @@ Version: `1.114.0-insider` · Branch: `main` · Upstream: [microsoft/vscode](htt
   > Changes workingDirectory from a string to a URI throughout the agent host stack for more accurate and consistent path handling across remote and local scenarios.
 - [#306141](https://github.com/microsoft/vscode/pull/306141) **debt - cleanup from sidebar support in modal editors**
   > Removes leftover modal editor sidebar size settings and consolidates changes list rendering logic so both main and sidebar views share code and styling.
-- [#306128](https://github.com/microsoft/vscode/pull/306128) **prompt service: simplify types, remove ExtensionAgentSourceType & IResolvedPromptFile**
+- [#306128](https://github.com/microsoft/vscode/pull/306128) **prompt service: simplify types, remove ExtensionAgentSourceType &amp; IResolvedPromptFile**
   > Simplifies prompt service types by removing redundant interfaces and centralizing prompt source tracking, streamlining skill discovery and prompt file handling.
 - [#306132](https://github.com/microsoft/vscode/pull/306132) **sessions: decouple sessions layer from agent sessions dependencies**
   > Decouples sessions management from agent session implementations by removing direct dependencies and relying on sessions abstractions for cleaner separation.

--- a/docs/builds/2026-04-01_17-49Z_1.115.0-insider_54b695e.md
+++ b/docs/builds/2026-04-01_17-49Z_1.115.0-insider_54b695e.md
@@ -150,7 +150,7 @@ Version: `1.115.0-insider` · Branch: `main` · Upstream: [microsoft/vscode](htt
   > Cleans up Sessions Changes UI by moving git-diff observables from view to view model, centralizing diff state management.
 - [#307044](https://github.com/microsoft/vscode/pull/307044) **sessions - cleanup window opening handling**
   > Cleans up agent/sessions window opening to use consistent config shapes and ensure CLI args are passed correctly to new windows.
-- [#306484](https://github.com/microsoft/vscode/pull/306484) **Updates component explorer & adopts rspack for fixture serving**
+- [#306484](https://github.com/microsoft/vscode/pull/306484) **Updates component explorer &amp; adopts rspack for fixture serving**
   > Updates component explorer and migrates to rspack for serving component fixtures, improving build and test workflows.
 - [#306951](https://github.com/microsoft/vscode/pull/306951) **Sessions - move more code into the view model**
   > Moves additional logic from Sessions view into the view model to better separate concerns and simplify the view layer.

--- a/docs/builds/2026-04-02_04-07Z_1.115.0-insider_b826afb.md
+++ b/docs/builds/2026-04-02_04-07Z_1.115.0-insider_b826afb.md
@@ -28,7 +28,7 @@ Version: `1.115.0-insider` · Branch: `main` · Upstream: [microsoft/vscode](htt
 ## 🐛 FIXES
 
 - [#307305](https://github.com/microsoft/vscode/pull/307305) **agentPlugins: prefix skills with plugin name consistent with commands**
-  > Fixes chat plugin slash command naming so plugin skills always show with the correct <plugin>: prefix, improving consistency in chat command display.
+  > Fixes chat plugin slash command naming so plugin skills always show with the correct &lt;plugin&gt;: prefix, improving consistency in chat command display.
 - [#307282](https://github.com/microsoft/vscode/pull/307282) **Sessions - branch picker should show active branch name when using folder sessions**
   > Updates branch picker in folder-isolated chat sessions to always show the current active Git branch, keeping UI branch info accurate.
 - [#307300](https://github.com/microsoft/vscode/pull/307300) **Revert "Allow intellisense for troubleshoot skill (#305702)"**

--- a/docs/builds/2026-04-03_16-58Z_1.115.0-insider_3d70aab.md
+++ b/docs/builds/2026-04-03_16-58Z_1.115.0-insider_3d70aab.md
@@ -24,7 +24,7 @@ Version: `1.115.0-insider` · Branch: `main` · Upstream: [microsoft/vscode](htt
 - [#307604](https://github.com/microsoft/vscode/pull/307604) **make sure confirmation needed subagents are not marked inactive**
   > Prevented chat subagent parts from hiding confirmation dialogs by keeping them active until all tool confirmations are done.
 - [#307584](https://github.com/microsoft/vscode/pull/307584) **chore: add npm version check to preinstall**
-  > Added a preinstall check to block unsupported npm versions (>=11.2.0), preventing issues during setup caused by incompatible npm releases.
+  > Added a preinstall check to block unsupported npm versions (&gt;=11.2.0), preventing issues during setup caused by incompatible npm releases.
 
 ## 🔨 REFACTORS
 

--- a/docs/builds/2026-04-09_03-24Z_1.116.0-insider_e4f6e11.md
+++ b/docs/builds/2026-04-09_03-24Z_1.116.0-insider_e4f6e11.md
@@ -55,8 +55,8 @@ Version: `1.116.0-insider` · Branch: `main` · Upstream: [microsoft/vscode](htt
   > Fixed repository path detection in Sessions Changes view by deriving the repo path from session metadata instead of relying on workspace repository.
 - [#308586](https://github.com/microsoft/vscode/pull/308586) **Revert "temporarily disable TSA"**
   > Reverted changes that temporarily disabled TSA uploads in Azure Pipelines to restore SDL/TSA compliance reporting in official builds.
-- [#308583](https://github.com/microsoft/vscode/pull/308583) **Sessions - only show "Commit & Sync" and "Sync Changes" action when the branch has an upstream**
-  > Updated Sessions UI to only show 'Commit & Sync' and 'Sync Changes' actions when the active branch has an upstream configured.
+- [#308583](https://github.com/microsoft/vscode/pull/308583) **Sessions - only show "Commit &amp; Sync" and "Sync Changes" action when the branch has an upstream**
+  > Updated Sessions UI to only show 'Commit &amp; Sync' and 'Sync Changes' actions when the active branch has an upstream configured.
 - [#308394](https://github.com/microsoft/vscode/pull/308394) **feat(testing): support alternative semantic index endpoints**
   > Improved scenario-automation workspace chunk search by applying glob filters, wiring request cancellation, and adding unit tests for robustness.
 - [#308581](https://github.com/microsoft/vscode/pull/308581) **sessions: fix in-progress description overflow in session list**

--- a/docs/builds/2026-04-13_03-08Z_1.116.0-insider_1dfb3b9.md
+++ b/docs/builds/2026-04-13_03-08Z_1.116.0-insider_1dfb3b9.md
@@ -48,9 +48,9 @@ Version: `1.116.0-insider` · Branch: `main` · Upstream: [microsoft/vscode](htt
 ## 🐛 FIXES
 
 - [#309308](https://github.com/microsoft/vscode/pull/309308) **chat: handle invalid URIs in extractCodeblockUrisFromText**
-  > Fixes crashes in chat rendering when invalid URIs appear inside <vscode_codeblock_uri> tags by safely handling URI parse failures and adding related tests.
+  > Fixes crashes in chat rendering when invalid URIs appear inside &lt;vscode_codeblock_uri&gt; tags by safely handling URI parse failures and adding related tests.
 - [#309336](https://github.com/microsoft/vscode/pull/309336) **chat: fix body tag leaking into rendered markdown when content ends with code block**
-  > Fixes markdown rendering in chat so ending fenced code blocks don’t include the closing </body> tag as visible text by adding extra line breaks before </body>.
+  > Fixes markdown rendering in chat so ending fenced code blocks don’t include the closing &lt;/body&gt; tag as visible text by adding extra line breaks before &lt;/body&gt;.
 - [#309218](https://github.com/microsoft/vscode/pull/309218) **Sessions test on property**
   > Adjusts the Sessions E2E workflow trigger to manual only, preventing notification emails for unwanted automatic runs and allowing manual test execution.
 - [#309324](https://github.com/microsoft/vscode/pull/309324) **chat: queue/steer falls back to normal send when idle**
@@ -79,7 +79,7 @@ Version: `1.116.0-insider` · Branch: `main` · Upstream: [microsoft/vscode](htt
   > Reduces oversized chat prompt payloads by replacing historical tool result images with placeholders and enforcing a shared image size budget per turn.
 - [#309117](https://github.com/microsoft/vscode/pull/309117) **agents: ellipsize titlebar repo metadata first**
   > Makes the Agent Sessions title bar truncate (ellipsize) repository metadata before the main session title, preserving the primary title's readability in narrow layouts.
-- [#309112](https://github.com/microsoft/vscode/pull/309112) **fix: AI customization welcome page - prefill active session & update placeholder**
+- [#309112](https://github.com/microsoft/vscode/pull/309112) **fix: AI customization welcome page - prefill active session &amp; update placeholder**
   > Improves AI customization welcome page by updating placeholder text and fixing prefill behavior to target the active chat session instead of always opening a new session.
 - [#309106](https://github.com/microsoft/vscode/pull/309106) **product: rename GHE.com label to GHE**
   > Renames the enterprise authentication provider label from ‘GHE.com’ to ‘GHE’ in product.json for a shorter, clearer display in sign-in UI.

--- a/docs/builds/2026-04-20_03-39Z_1.117.0-insider_173f07e.md
+++ b/docs/builds/2026-04-20_03-39Z_1.117.0-insider_173f07e.md
@@ -14,7 +14,7 @@ Version: `1.117.0-insider` · Branch: `main` · Upstream: [microsoft/vscode](htt
   > Adds a function to clear the todo list at session start and hides the todo widget when empty, improving user experience by preventing empty todo displays.
 - [#311283](https://github.com/microsoft/vscode/pull/311283) **heap-snapshot-analysis skill improvements**
   > Adds new streaming utilities and guidance for analyzing large V8 heap snapshots, improving memory efficiency when handling huge snapshots.
-- [#311281](https://github.com/microsoft/vscode/pull/311281) **instructions: enhance touch & iOS compatibility guidelines for Agents window**
+- [#311281](https://github.com/microsoft/vscode/pull/311281) **instructions: enhance touch &amp; iOS compatibility guidelines for Agents window**
   > Enhances Agents window contributor instructions with touch and iOS guidelines to prevent input bugs on touch devices.
 - [#311254](https://github.com/microsoft/vscode/pull/311254) **Surface worktree-created announcement in agent host Copilot CLI sessions**
   > Surfaces a "Created isolated worktree" announcement in agent-host Copilot CLI sessions during initial and restored responses for better user awareness.

--- a/docs/builds/2026-04-22_16-38Z_1.118.0-insider_40db337.md
+++ b/docs/builds/2026-04-22_16-38Z_1.118.0-insider_40db337.md
@@ -26,7 +26,7 @@ Version: `1.118.0-insider` · Branch: `main` · Upstream: [microsoft/vscode](htt
 - [#311907](https://github.com/microsoft/vscode/pull/311907) **Agents: Adjust padding for session section label**
   > Tweaks padding for the Agents session section header to improve spacing and alignment. Helps keep the Sessions UI looking consistent.
 - [#311471](https://github.com/microsoft/vscode/pull/311471) **fix command rewrite issue**
-  > Fixes terminal chat command rewriting for POSIX so it won’t add a duplicate background operator when the command already ends with ‘&’. Prevents ‘& &’-style command issues via added regression tests.
+  > Fixes terminal chat command rewriting for POSIX so it won’t add a duplicate background operator when the command already ends with ‘&amp;’. Prevents ‘&amp; &amp;’-style command issues via added regression tests.
 
 ## 🔨 REFACTORS
 

--- a/docs/builds/2026-04-23_06-49Z_1.118.0-insider_46e64ce.md
+++ b/docs/builds/2026-04-23_06-49Z_1.118.0-insider_46e64ce.md
@@ -35,7 +35,7 @@ Version: `1.118.0-insider` · Branch: `main` · Upstream: [microsoft/vscode](htt
   > Switches Copilot CLI session titles to use the shared SDK title source and syncs title changes across the sidebar, editor header, and terminal resume. Renames now stay consistent everywhere.
 - [#312078](https://github.com/microsoft/vscode/pull/312078) **agentHost: add diagnostic tracing for session disconnect errors**
   > Adds detailed diagnostic tracing around agent session disconnect/reconnect failures, especially “Session not found” after WebSocket reconnects. Helps engineers pinpoint the real failure path.
-- [#312013](https://github.com/microsoft/vscode/pull/312013) **SSH agent host: add agent forwarding setting & fix encrypted key failures**
+- [#312013](https://github.com/microsoft/vscode/pull/312013) **SSH agent host: add agent forwarding setting &amp; fix encrypted key failures**
   > Fixes SSH remote agent host auth by skipping fallback privateKey parsing when an SSH agent socket is present, avoiding encrypted key parse failures. Adds an opt-in setting to forward the SSH agent to the remote host.
 - [#312067](https://github.com/microsoft/vscode/pull/312067) **less auto expand on mobile**
   > Improves mobile-web behavior by preventing the Sessions auxiliary bar from auto-expanding or auto-showing during session switches/turn completion. Reduces disruption on narrow screens.
@@ -59,8 +59,8 @@ Version: `1.118.0-insider` · Branch: `main` · Upstream: [microsoft/vscode](htt
   > Increases the GitHub avatar size in the Sessions titlebar account widget from 16×16 to 18×18. Keeps the surrounding control size the same for consistent layout.
 - [#312032](https://github.com/microsoft/vscode/pull/312032) **Revert "fix(build): use Bearer auth for GitHub API requests in fetch.ts"**
   > Reverts a build change that used Bearer auth for GitHub API fetches and restores the previous Basic auth formatting. Aimed at fixing build-time GitHub asset fetch failures.
-- [#312019](https://github.com/microsoft/vscode/pull/312019) **Strip redundant \`cd <workingDirectory> &&\` prefix from agent host shell tool calls**
-  > Removes redundant `cd <workingDirectory> &&` prefixes from agent host shell tool commands so AHP clients show cleaner commands. Adds conditional logic and tests to ensure stripping only happens when appropriate.
+- [#312019](https://github.com/microsoft/vscode/pull/312019) **Strip redundant \`cd &lt;workingDirectory&gt; &amp;&amp;\` prefix from agent host shell tool calls**
+  > Removes redundant `cd &lt;workingDirectory&gt; &amp;&amp;` prefixes from agent host shell tool commands so AHP clients show cleaner commands. Adds conditional logic and tests to ensure stripping only happens when appropriate.
 - [#312033](https://github.com/microsoft/vscode/pull/312033) **Revert "ci: switch PR workflows back to 1ES self-hosted runners with JobId"**
   > Reverts a CI runner workflow change back to 1ES self-hosted runners with JobId. Intended to restore the prior PR validation execution environment and avoid intermittent cancellations.
 - [#312005](https://github.com/microsoft/vscode/pull/312005) **Remove upgrade and plan branching for weekly rate limit messaging**

--- a/docs/builds/2026-04-24_16-58Z_1.118.0-insider_f2b51f3.md
+++ b/docs/builds/2026-04-24_16-58Z_1.118.0-insider_f2b51f3.md
@@ -62,7 +62,7 @@ Version: `1.118.0-insider` · Branch: `main` · Upstream: [microsoft/vscode](htt
 - [#312328](https://github.com/microsoft/vscode/pull/312328) **MultiFileDiffEditor - fix flickering on diff editors when switching resources**
   > Fixes flickering in MultiFileDiffEditor when switching resources by keeping diff item view models alive across transient changes using ref-counting. Results in steadier diff UI updates.
 - [#307059](https://github.com/microsoft/vscode/pull/307059) **contextkey: fix scanner returning '>=' instead of '>' for greater-than operator**
-  > Corrects the context key scanner so the greater-than operator token (>) is reconstructed properly instead of returning >=. Improves correctness of token-to-text output.
+  > Corrects the context key scanner so the greater-than operator token (&gt;) is reconstructed properly instead of returning &gt;=. Improves correctness of token-to-text output.
 - [#312317](https://github.com/microsoft/vscode/pull/312317) **actions: lazy-update MenuWorkbenchToolBar based on visibility**
   > Optimizes MenuWorkbenchToolBar updates by attaching change listeners only when the toolbar is actually visible, using IntersectionObserver. Reduces unnecessary layout-triggering updates when the toolbar is off-screen.
 - [#312156](https://github.com/microsoft/vscode/pull/312156) **copilot: remove InlineDocIntent and /doc command**

--- a/docs/builds/2026-04-27_03-13Z_1.118.0-insider_8ae0d8e.md
+++ b/docs/builds/2026-04-27_03-13Z_1.118.0-insider_8ae0d8e.md
@@ -137,7 +137,7 @@ Version: `1.118.0-insider` · Branch: `main` · Upstream: [microsoft/vscode](htt
 - [#312417](https://github.com/microsoft/vscode/pull/312417) **Agents web: Registering SessionsWorkspaceContextService**
   > Registers Sessions workspace context and configuration services in the web Agents workbench, matching the desktop approach while avoiding standard workspace watchers. Helps align behavior and reduces wasted work.
 - [#312440](https://github.com/microsoft/vscode/pull/312440) **Rework titlebar item to use View > Browser command**
-  > Reworks a titlebar item to use the `View > Browser` command path. Helps ensure the titlebar action behaves correctly across contexts.
+  > Reworks a titlebar item to use the `View &gt; Browser` command path. Helps ensure the titlebar action behaves correctly across contexts.
 - [#312257](https://github.com/microsoft/vscode/pull/312257) **Agents web: drop [hostname] from remote agent host session labels**
   > On web only, simplifies remote agent host session labels by dropping redundant hostname suffixes in group headers and card descriptions. Helps reduce visual clutter without changing desktop behavior.
 
@@ -152,7 +152,7 @@ Version: `1.118.0-insider` · Branch: `main` · Upstream: [microsoft/vscode](htt
 - [#312553](https://github.com/microsoft/vscode/pull/312553) **Adopt message attachment URI protocol**
   > Updates agent-host protocol attachments to use the new `uri` field name, threading serialized URIs through VS Code and converting to SDK path/filePath at the boundary. Helps keep attachments compatible with protocol c...
 - [#312491](https://github.com/microsoft/vscode/pull/312491) **BYOK: support tool\_search for Claude Opus 4.7**
-  > Adds tool_search support for Claude Opus 4.7 BYOK model ID formats, including `@<version>` suffixes, and updates tests. Helps tool search work with more model IDs.
+  > Adds tool_search support for Claude Opus 4.7 BYOK model ID formats, including `@&lt;version&gt;` suffixes, and updates tests. Helps tool search work with more model IDs.
 - [#312161](https://github.com/microsoft/vscode/pull/312161) **Bump openssl from 0.10.75 to 0.10.78 in /cli**
   > Bumps OpenSSL in the /cli build from 0.10.75 to 0.10.78. Helps pick up security/bug fixes from the newer OpenSSL version.
 - [#312250](https://github.com/microsoft/vscode/pull/312250) **sessions: update Open in VS Code titlebar button with hover animation and full-color icon**

--- a/docs/builds/2026-04-28_16-59Z_1.119.0-insider_81e19a6.md
+++ b/docs/builds/2026-04-28_16-59Z_1.119.0-insider_81e19a6.md
@@ -95,8 +95,8 @@ Version: `1.119.0-insider` · Branch: `main` · Upstream: [microsoft/vscode](htt
   > Fixes duplicated question text from agent host sessions. Improves the correctness of how question prompts are displayed in the UI.
 - [#312824](https://github.com/microsoft/vscode/pull/312824) **Remove anthropic.thinking.budgetTokens setting and hardcode budget to 16000**
   > Removes the Anthropic thinking budget setting and hardcodes the thinking budget to 16000. Simplifies configuration while keeping the previous default behavior.
-- [#312751](https://github.com/microsoft/vscode/pull/312751) **Fix MCP install manifest dialog showing literal '&&Install' label**
-  > Fixes an MCP install dialog where the OK button showed `&&Install` literally. Wraps the label with mnemonic handling so each platform renders it correctly.
+- [#312751](https://github.com/microsoft/vscode/pull/312751) **Fix MCP install manifest dialog showing literal '&amp;&amp;Install' label**
+  > Fixes an MCP install dialog where the OK button showed `&amp;&amp;Install` literally. Wraps the label with mnemonic handling so each platform renders it correctly.
 - [#312798](https://github.com/microsoft/vscode/pull/312798) **Fix "Object has been destroyed" error when BrowserView is disposed after window close**
   > Prevents an “Object has been destroyed” error when disposing a BrowserView after the Electron window closes by guarding `removeChildView` with `!win.isDestroyed()`. Improves shutdown stability.
 - [#312750](https://github.com/microsoft/vscode/pull/312750) **Agents welcome: improve sign-in flow, loading state, and sign-out reset**

--- a/docs/builds/2026-04-30_04-38Z_1.119.0-insider_7e4091c.md
+++ b/docs/builds/2026-04-30_04-38Z_1.119.0-insider_7e4091c.md
@@ -49,8 +49,8 @@ Version: `1.119.0-insider` · Branch: `main` · Upstream: [microsoft/vscode](htt
   > Fixes SessionModelPicker logic so it handles empty model lists safely and re-applies the current model when switching active sessions. Prevents losing model selection during session changes.
 - [#313381](https://github.com/microsoft/vscode/pull/313381) **Make sure we still set isInitialized when git is disabled or not active**
   > Ensures Copilot’s GitServiceImpl is marked initialized even when Git is disabled or unavailable. This prevents callers from hanging while waiting for initialization.
-- [#313379](https://github.com/microsoft/vscode/pull/313379) **Detach rewriter: also wrap sync-mode commands ending in trailing &**
-  > Extends background detaching so sync-mode commands ending with a trailing POSIX `&` get wrapped when the detach setting is enabled. Helps eval harnesses keep background services alive instead of dying when the tool te...
+- [#313379](https://github.com/microsoft/vscode/pull/313379) **Detach rewriter: also wrap sync-mode commands ending in trailing &amp;**
+  > Extends background detaching so sync-mode commands ending with a trailing POSIX `&amp;` get wrapped when the detach setting is enabled. Helps eval harnesses keep background services alive instead of dying when the tool te...
 - [#313141](https://github.com/microsoft/vscode/pull/313141) **Fix flaky statusbar smoke test (TOCTOU race in click)**
   > Stabilizes a flaky Playwright smoke test by using a more robust click path that avoids a TOCTOU race when clicking status bar items. Adds a fallback only for known overlay-interception cases.
 - [#313369](https://github.com/microsoft/vscode/pull/313369) **Fix DisposableStore reference leak in terminal execute strategies**

--- a/scripts/update-data.mjs
+++ b/scripts/update-data.mjs
@@ -236,11 +236,15 @@ function mdEscapeInline(text) {
 
 function mdEscapeEmphasis(text) {
   // Escape characters that commonly break bold/italic markdown.
+  // Also escape HTML special characters to prevent Vue parser errors on unclosed tags.
   return mdEscapeInline(text)
     .replaceAll("\\", "\\\\")
     .replaceAll("*", "\\*")
     .replaceAll("_", "\\_")
-    .replaceAll("`", "\\`");
+    .replaceAll("`", "\\`")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
 }
 
 async function getInsidersInstallerLinksForBuild(buildSha) {
@@ -430,10 +434,23 @@ function extractJsonObjectFromText(raw) {
   }
 }
 
+function sanitizeExplainerForMarkdown(text) {
+  // Escape HTML special characters to prevent Vue parser from attempting to parse them as tags.
+  // This prevents "Element is missing end tag" errors when explainer contains < > or &.
+  let t = String(text || "");
+  // Escape & first to avoid double-escaping
+  t = t.replaceAll("&", "&amp;");
+  t = t.replaceAll("<", "&lt;");
+  t = t.replaceAll(">", "&gt;");
+  return t;
+}
+
 function clampExplainer(text) {
-  const t = String(text || "").replaceAll("\r", "").replaceAll("\n", " ").trim();
+  let t = String(text || "").replaceAll("\r", "").replaceAll("\n", " ").trim();
   if (!t) return "Internal maintenance/refactoring; no user-visible change expected.";
-  return t.length > 220 ? (t.slice(0, 217).trimEnd() + "...") : t;
+  t = t.length > 220 ? (t.slice(0, 217).trimEnd() + "...") : t;
+  // Sanitize for markdown/Vue safety
+  return sanitizeExplainerForMarkdown(t);
 }
 
 function normalizePrChangeLabel(labelRaw) {
@@ -535,7 +552,9 @@ function buildExplainersMarkdown({ pullRequests, explainersByNumber }) {
         lines.push(`- **${title || "(untitled change)"}**`);
       }
       // Use a markdown quote instead of a nested list item.
-      lines.push(`  > ${entry.explainer}`);
+      // entry.explainer is already sanitized by clampExplainer, but re-sanitize for safety
+      const sanitized = sanitizeExplainerForMarkdown(entry.explainer);
+      lines.push(`  > ${sanitized}`);
     }
 
     lines.push("");


### PR DESCRIPTION
## Description

This PR fixes VitePress build failures caused by unclosed HTML tags in generated markdown files. When PR titles or AI-generated explainers contain angle brackets (e.g., `<plugin>`, `<workingDirectory>`), the Vue parser attempts to interpret them as HTML elements and throws "Element is missing end tag" errors.

## Changes

### Generator (`scripts/update-data.mjs`)
- **Added `sanitizeExplainerForMarkdown()` function**: Escapes HTML special characters (`&`, `<`, `>`) to prevent Vue parser errors
- **Updated `mdEscapeEmphasis()`**: Now also escapes HTML entities in PR titles and emphasized text to prevent unclosed tag errors
- **Updated `clampExplainer()`**: Applies sanitization to explainer text before processing
- **Modified `buildExplainersMarkdown()`**: Ensures blockquote content is properly sanitized before output

### Existing Markdown Files
- Fixed 15 markdown files in `docs/builds/` that contained unclosed HTML tags
- Both PR titles and blockquote explainers are now properly escaped

## Testing

✅ VitePress build completes successfully (`npm run docs:build`)
✅ All previously failing markdown files now parse correctly
✅ HTML entities render correctly in the final output (e.g., `&lt;plugin&gt;` displays as `<plugin>`)

## Fixes

Fixes #24